### PR TITLE
WIP save setting when tr2d is closed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,4 +138,24 @@
 			<url>http://maven.imagej.net/content/groups/public</url>
 		</repository>
 	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.6.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<mainClass>com.indago.tr2d.app.garcia.Tr2dApplication</mainClass>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 		<dependency>
 			<groupId>com.indago</groupId>
 			<artifactId>tr2d</artifactId>
+			<version>0.1.6-SNAPSHOT</version>
 		</dependency>
 
 		<!-- SEGMENTATION PLUGINS -->
@@ -63,6 +64,7 @@
 		<dependency>
 			<groupId>com.indago.tr2d</groupId>
 			<artifactId>Tr2dLabkitSegmentationPlugin</artifactId>
+			<version>0.1.4-SNAPSHOT</version>
 		</dependency>
 
 		<!-- OTHER DEPENDENCIES -->

--- a/src/main/java/com/indago/tr2d/app/garcia/Tr2dApplication.java
+++ b/src/main/java/com/indago/tr2d/app/garcia/Tr2dApplication.java
@@ -152,7 +152,7 @@ public class Tr2dApplication {
 			mainPanel = new Tr2dMainPanel( guiFrame, model, log );
 
 			guiFrame.getContentPane().add( mainPanel );
-			setFrameSizeAndCloseOperation();
+			setFrameSizeAndCloseOperation( model );
 			guiFrame.setVisible( true );
 			mainPanel.collapseLog();
 
@@ -166,7 +166,7 @@ public class Tr2dApplication {
 		}
 	}
 
-	private void setFrameSizeAndCloseOperation() {
+	private void setFrameSizeAndCloseOperation( Tr2dModel model ) {
 		try {
 			FrameProperties.load( projectFolder.getFile( Tr2dProjectFolder.FRAME_PROPERTIES ).getFile(), guiFrame );
 		} catch ( final IOException e ) {
@@ -192,6 +192,7 @@ public class Tr2dApplication {
 				if ( choice == 0 ) {
 					runOptionalExport();
 
+					model.close();
 					try {
 						FrameProperties.save( projectFolder.getFile( Tr2dProjectFolder.FRAME_PROPERTIES ).getFile(), guiFrame );
 					} catch ( final Exception e ) {


### PR DESCRIPTION
This PR depends on a similar PR in tr2d.
It enables the labkit segmentation plugin and the manual segmentation tab to save settings when the Tr2d main window is closed.